### PR TITLE
Fix cron scheduling pattern

### DIFF
--- a/lib/cron/storage-events.js
+++ b/lib/cron/storage-events.js
@@ -16,7 +16,7 @@ function StorageEventsCron(config) {
   this._config = config;
 }
 
-StorageEventsCron.CRON_TIME = '* */10 * * * *'; // every ten minutes
+StorageEventsCron.CRON_TIME = '00 */10 * * * *'; // every ten minutes
 StorageEventsCron.MAX_RUN_TIME = 600000; // 10 minutes
 StorageEventsCron.FINALITY_TIME = 10800000; // 3 hours
 


### PR DESCRIPTION
`* */10 * * * *` will trigger the cron job once for _every second_ in the 10th minute of the hour, i.e. at 9:40:00, 9:40:01, 9:40:02, ..., 9:40:59 - total of 60 times in that minute.

If the intention is to trigger it only once at 9:40:00 then the correct cron pattern is `00 */10 * * * *`.