### PR TITLE
Fix for deleting empty bucket

### DIFF
--- a/lib/server/routes/buckets.js
+++ b/lib/server/routes/buckets.js
@@ -355,27 +355,23 @@ BucketsRouter.prototype.destroyBucketById = function(req, res, next) {
   const userId = req.user._id;
   const bucketId = req.params.id;
 
-  this._getShardHashesByBucketId(userId, bucketId, (err, hashes) => {
+  Bucket.findOne({
+    _id: bucketId,
+    user: userId
+  }, (err, bucket) => {
     if (err) {
-      log.warn('destroyBucketById: storage event aggregation failed, reason: %s',
-               err.message);
       return next(new errors.InternalError(err.message));
     }
 
-    if (!hashes || !hashes.length) {
+    if (!bucket) {
       return next(new errors.NotFoundError('Bucket not found'));
     }
-
-    Bucket.findOne({
-      _id: bucketId,
-      user: userId
-    }, (err, bucket) => {
+      
+    this._getShardHashesByBucketId(userId, bucketId, (err, hashes) => {
       if (err) {
+        log.warn('destroyBucketById: storage event aggregation failed, reason: %s',
+                  err.message);
         return next(new errors.InternalError(err.message));
-      }
-
-      if (!bucket) {
-        return next(new errors.NotFoundError('Bucket not found'));
       }
 
       // Because we don't have atomic transactions, we'll first update


### PR DESCRIPTION
Deleting empty bucket failed with "404 Bucket not found" because no shards were found for this bucket.