### PR TITLE
Change `req.user.id` to `req.user._id` to match middleware _id assignment

### DIFF
--- a/lib/server/routes/reports.js
+++ b/lib/server/routes/reports.js
@@ -184,8 +184,6 @@ ReportsRouter.prototype.createExchangeReport = function(req, res, next) {
       return next(new errors.BadRequestError('Invalid exchange report'));
     }
 
-    log.debug('req.user: ', req.user)
-
     const isClientReport = req.user ?
           (event.client === req.user._id) : req.farmerNodeID ?
           (event.client === req.farmerNodeID) : false;

--- a/lib/server/routes/reports.js
+++ b/lib/server/routes/reports.js
@@ -184,8 +184,10 @@ ReportsRouter.prototype.createExchangeReport = function(req, res, next) {
       return next(new errors.BadRequestError('Invalid exchange report'));
     }
 
+    log.info('req.user: ', req.user)
+
     const isClientReport = req.user ?
-          (event.client === req.user.id) : req.farmerNodeID ?
+          (event.client === req.user._id) : req.farmerNodeID ?
           (event.client === req.farmerNodeID) : false;
     const isFarmerReport = req.farmerNodeID ?
           (event.farmer === req.farmerNodeID) : false;

--- a/lib/server/routes/reports.js
+++ b/lib/server/routes/reports.js
@@ -184,8 +184,10 @@ ReportsRouter.prototype.createExchangeReport = function(req, res, next) {
       return next(new errors.BadRequestError('Invalid exchange report'));
     }
 
+    log.debug('req.user: ', req.user)
+
     const isClientReport = req.user ?
-          (event.client === req.user.id) : req.farmerNodeID ?
+          (event.client === req.user._id) : req.farmerNodeID ?
           (event.client === req.farmerNodeID) : false;
     const isFarmerReport = req.farmerNodeID ?
           (event.farmer === req.farmerNodeID) : false;


### PR DESCRIPTION
`event.client` wouldn't correctly compare against `req.user._id` because it wasn't being referenced correctly. This caused a logic breakdown in whether reports were being recognized as farmer reports.